### PR TITLE
fix decay of PO and SC

### DIFF
--- a/Source/Instance/InstanceData.cs
+++ b/Source/Instance/InstanceData.cs
@@ -37,7 +37,9 @@ namespace StateFunding
                 NewReviews[i] = Reviews[i];
             }
             NewReviews[NewReviews.Length - 1] = R;
-
+            InstanceData Inst = StateFundingGlobal.fetch.GameInstance;
+            Inst.po = R.finalPO;
+            Inst.sc = R.finalSC;
             Reviews = NewReviews;
         }
 

--- a/Source/Review/Review.cs
+++ b/Source/Review/Review.cs
@@ -387,7 +387,7 @@ namespace StateFunding
                 tmpPO += Bases[i].po;
             }
 
-            finalPO = tmpPO;
+            finalPO = (int)Math.Ceiling(tmpPO * (1 - StateFundingGlobal.convergingRate));
         }
 
         public void UpdateFinalSC()
@@ -425,7 +425,7 @@ namespace StateFunding
                 tmpSC += Bases[i].sc;
             }
 
-            finalSC = tmpSC;
+            finalSC = (int)Math.Ceiling(tmpSC * (1 - StateFundingGlobal.convergingRate));
         }
 
         private void UpdateFunds()

--- a/Source/Review/ReviewManager.cs
+++ b/Source/Review/ReviewManager.cs
@@ -27,9 +27,6 @@ namespace StateFunding
             // Start a new review
             Inst.ActiveReview = new Review();
 
-            // Apply PO/SC decay on instance
-            ApplyDecay();
-
             // Apply funds from Review
             Log.Info("Adding Funds: " + Rev.funds);
             Funding.Instance.AddFunds(Rev.funds, TransactionReasons.None);
@@ -38,47 +35,6 @@ namespace StateFunding
             ReviewToastView Toast = new ReviewToastView(Rev);
 
             Log.Info("Generated Review");
-        }
-
-        public void ApplyDecay()
-        {
-            Log.Info("Applying Decay");
-            InstanceData Inst = StateFundingGlobal.fetch.GameInstance;
-            if (Inst == null)
-            {
-                Log.Error("ReviewManager.ApplyDecay, Inst is null");
-                return;
-            }
-
-            if (Inst.po > 0)
-            {
-                int newPO = Inst.po - (int)Math.Ceiling(Inst.po * 0.2);
-                newPO = Math.Max(0, newPO);
-
-                Inst.po = newPO;
-            }
-            else
-            {
-                int newPO = Inst.po += (int)Math.Ceiling(Inst.po * -0.2);
-                newPO = Math.Min(0, newPO);
-
-                Inst.po = newPO;
-            }
-
-            if (Inst.sc > 0)
-            {
-                int newSC = Inst.sc - (int)Math.Ceiling(Inst.sc * 0.2);
-                newSC = Math.Max(0, newSC);
-
-                Inst.sc = newSC;
-            }
-            else
-            {
-                int newSC = Inst.sc += (int)Math.Ceiling(Inst.sc * -0.2);
-                newSC = Math.Min(0, newSC);
-
-                Inst.sc = newSC;
-            }
         }
 
         public void OpenReview(Review Rev)

--- a/Source/StateFunding/StateFundingGlobal.cs
+++ b/Source/StateFunding/StateFundingGlobal.cs
@@ -7,6 +7,7 @@ namespace StateFunding
         public static StateFunding fetch;
         public static bool isLoaded;
         public static bool needsDataInit;
+        public static float convergingRate = 0.5f;
     }
 }
 


### PR DESCRIPTION
After budget review, finalPo was not being carried over to po for the next budget so only "decay" was being applied.
finalPO was not taking "decay" into consideration.
Decay is not really decay, its more of a converging function under the form of this formula:
PO(t+1) = (PO(t) + modPO(t+1)) * (1 - rate)
where rate was hard coded at 0.2 and modPO is the modifiers for the burget review
I changed the rate to 0.5 because at 0.2 the formula would converge at 4 * modPO which would be confusing.