### PR TITLE
Added RealAntennas alias

### DIFF
--- a/GameData/StateFunding/data/modulealiases.settings
+++ b/GameData/StateFunding/data/modulealiases.settings
@@ -52,6 +52,11 @@
 			{
 				name = Antenna
 			}
+			//Following needed for RealAntennas
+			Item
+			{
+				name = ModuleRealAntenna
+			}
 		}
 	}
 	Item 


### PR DESCRIPTION
Documented over in [RA's wiki](https://github.com/DRVeyl/RealAntennas/wiki/Part-Configs). It deletes the stock ModuleDataTransmitter and replaces it with its own ModuleRealAntenna. 
